### PR TITLE
flamecast: edit the readme to say hello from flamecast fr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# ClankerLoop
-
-A monorepo containing a Next.js web app and Cloudflare Workers backend. Check it out at [ClankerLoop.com](https://ClankerLoop.com).
+hello from flamecast fr
 
 ![Demo](public/demo.gif)
 


### PR DESCRIPTION

Updates the README to display a simple greeting message from Flamecast, replacing the previous project description for ClankerLoop.

## Changes

- Replaced the project title and description with "hello from flamecast fr"
- Removed the reference to the monorepo structure (Next.js web app and Cloudflare Workers backend)
- Removed the link to ClankerLoop.com
- Retained the demo GIF reference